### PR TITLE
NOTICKET: Fix condition in RT sys count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -355,11 +355,11 @@ resource "aws_route_table" "intra" {
 
 ################################################################################
 # Sys routes
-# There are as many routing tables as the number of NAT gateways
+# There are as many routing tables as the number of sys subnets
 ################################################################################
 
 resource "aws_route_table" "sys" {
-  count = local.create_vpc && length(var.sys_subnets) > 0 ? 1 : 0
+  count = local.create_vpc && length(var.sys_subnets) > 0 ? length(var.sys_subnets) : 0
 
   vpc_id = local.vpc_id
 

--- a/main.tf
+++ b/main.tf
@@ -359,7 +359,7 @@ resource "aws_route_table" "intra" {
 ################################################################################
 
 resource "aws_route_table" "sys" {
-  count = local.create_vpc && local.max_subnet_length > 0 ? local.nat_gateway_count : 0
+  count = local.create_vpc && length(var.sys_subnets) > 0 ? 1 : 0
 
   vpc_id = local.vpc_id
 


### PR DESCRIPTION
Fix the condition on sys Route Tables, if sys subnets weren't specified, route tables were created anyways